### PR TITLE
refactor: `phase-2 발행한 로또 수량 및 번호` 리팩토링 진행

### DIFF
--- a/__tests__/models/LottoStoreTest.js
+++ b/__tests__/models/LottoStoreTest.js
@@ -33,9 +33,18 @@ describe('LottoStore 모델 테스트', () => {
     Random.pickUniqueNumbersInRange.mockReturnValue([1, 2, 3, 4, 5, 6]);
 
     const purchaseAmount = 2000;
-    const lottos = new LottoStore(purchaseAmount).getUserLottos();
+    const userLottos = new LottoStore(purchaseAmount).getUserLottos();
 
-    expect(lottos).toHaveLength(2);
-    lottos.forEach(lotto => expect(lotto).toEqual([1, 2, 3, 4, 5, 6]));
+    expect(userLottos).toHaveLength(2);
+    userLottos.forEach(lotto => expect(lotto).toEqual([1, 2, 3, 4, 5, 6]));
+  });
+
+  test('getUserLottos() 반환 값 타입 테스트', () => {
+    const purchaseAmount = 1000;
+    const userLottos = new LottoStore(purchaseAmount).getUserLottos();
+
+    userLottos.forEach(userLotto =>
+      userLotto.forEach(number => expect(typeof number).toBe('number')),
+    );
   });
 });

--- a/docs/README.md
+++ b/docs/README.md
@@ -125,3 +125,14 @@
 - [x] 테스트를 통한 검증
   - [x] LottoStore 테스트 코드 추가
 - [x] JSDoc 작성
+
+### ✅ refactor-2 발행한 로또 수량 및 번호를 출력한다.
+
+- [x] `LottoStore` 리팩토링
+  - [x] `getUserLottos()` 메소드 책임 분리
+  - [x] 구입 수량 계산 분리 `getPurchaseQuantity()`
+  - [x] 로또 발급 분리 `publishLottos()`
+- [x] string 형 변환 후 발급받은 로또 출력
+- [x] Controller & Model에서는 number type을 유지 시키기 위해 OutputView에서 형 변환 후 출력
+- [x] 테스트를 통해 검증한다.
+  - [x] 발급받은 로또 type 체크

--- a/src/controller/LottoController.js
+++ b/src/controller/LottoController.js
@@ -36,17 +36,21 @@ class LottoController {
   async #buyLottos() {
     try {
       this.#purchaseAmount = await this.#inputView.readPurchaseAmount();
-      const LottoStoreInstance = new LottoStore(this.#purchaseAmount);
-      this.#userLottos = LottoStoreInstance.getUserLottos();
-
-      OutputView.printLottosQuantity(this.#userLottos.length);
-      OutputView.printLottos(
-        this.#userLottos.map(lotto => `[${lotto.join(', ')}]`),
-      );
+      this.lottoStore = new LottoStore(this.#purchaseAmount);
+      this.#userLottos = this.lottoStore.getUserLottos();
+      this.#printUserLottos();
     } catch (error) {
       OutputView.printError(error);
       await this.#buyLottos();
     }
+  }
+
+  /**
+   * 유저가 구입한 로또 개수와 로또 번호를 출력한다.
+   */
+  #printUserLottos() {
+    OutputView.printLottoQuantity(this.#userLottos.length);
+    OutputView.printLottoNumbers(this.#userLottos);
   }
 
   async #drawWinningNumbers() {

--- a/src/view/OutputView.js
+++ b/src/view/OutputView.js
@@ -1,32 +1,35 @@
 import { Console } from '@woowacourse/mission-utils';
 import { OUTPUT_MESSAGES } from '../constants/messages.js';
+import SYMBOLS from '../constants/symbols.js';
+
+const print = any => {
+  Console.print(any);
+};
 
 const OutputView = {
   printError(error) {
-    Console.print(error);
-    Console.print(`${error}`);
+    print(error);
+    print(`${error}`);
   },
 
-  printLottosQuantity(quantity) {
-    Console.print(OUTPUT_MESSAGES.lottosQuantity(quantity));
+  printLottoQuantity(quantity) {
+    print(OUTPUT_MESSAGES.lottosQuantity(quantity));
   },
 
-  printLottos(lottos) {
-    lottos.forEach(lotto => Console.print(lotto));
+  printLottoNumbers(lottos) {
+    lottos.forEach(lotto => print(`[${lotto.join(`${SYMBOLS.comma} `)}]`));
   },
 
   printResult() {
-    Console.print(OUTPUT_MESSAGES.result + OUTPUT_MESSAGES.divisionLine);
+    print(OUTPUT_MESSAGES.result + OUTPUT_MESSAGES.divisionLine);
   },
 
   printStats(stats) {
-    stats.forEach((stat, index) =>
-      Console.print(OUTPUT_MESSAGES.hits(stat, index)),
-    );
+    stats.forEach((stat, index) => print(OUTPUT_MESSAGES.hits(stat, index)));
   },
 
   printProfitRate(profitRate) {
-    Console.print(OUTPUT_MESSAGES.profitRate(profitRate));
+    print(OUTPUT_MESSAGES.profitRate(profitRate));
   },
 };
 


### PR DESCRIPTION
### ✅ refactor-2 발행한 로또 수량 및 번호를 출력한다.

- [x] `LottoStore` 리팩토링
  - [x] `getUserLottos()` 메소드 책임 분리
  - [x] 구입 수량 계산 분리 `getPurchaseQuantity()`
  - [x] 로또 발급 분리 `publishLottos()`
- [x] string 형 변환 후 발급받은 로또 출력
- [x] Controller & Model에서는 number type을 유지 시키기 위해 OutputView에서 형 변환 후 출력
- [x] 테스트를 통해 검증한다.
  - [x] 발급받은 로또 type 체크
  
  
---

  ```javascript
  getUserLottos() {
    this.#quantity = this.#purchaseAmount / OPTIONS.baseAmount;

    while (this.#quantity) {
      const lottoInstance = new Lotto(this.#getUniqueNumbers());
      this.#userLottos.push(lottoInstance.getUserLotto());
      this.#quantity -= 1;
    }

    return this.#userLottos;
  }
  
  
  ---



  #getPurchaseQuantity() {
    return this.#purchaseAmount / OPTIONS.baseAmount;
  }

  #publishLottos() {
    while (this.#purchaseQuantity) {
      this.#lotto = new Lotto(this.#getUniqueNumbers());
      this.#userLottos.push(this.#lotto.getUserLotto());
      this.#purchaseQuantity -= 1;
    }
  }

  getUserLottos() {
    this.#purchaseQuantity = this.#getPurchaseQuantity();
    this.#publishLottos();

    return this.#userLottos;
  }
```
